### PR TITLE
Include header dir to fix build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ generate_messages(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   CATKIN_DEPENDS roscpp rospy message_runtime
-#  INCLUDE_DIRS include
+  INCLUDE_DIRS include
 #  LIBRARIES kondo_driver
  #  DEPENDS system_lib
 )


### PR DESCRIPTION
`kondo_driver/include` directory wasn't ready without this.

###But even with this PR, the following error remains though.
```
/home/n130s/cws_drivers/src/longjie/kondo_driver/src/kondo_driver.cpp:16:35: fatal error: kondo_driver/setPower.h: No such file or directory
 #include "kondo_driver/setPower.h"                                 
```